### PR TITLE
chore: update devcontainer base images and pin Marp version

### DIFF
--- a/.devcontainer/playwright/devcontainer.json
+++ b/.devcontainer/playwright/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Playwright",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"image": "mcr.microsoft.com/devcontainers/base:bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 		},

--- a/.devcontainer/slides/devcontainer.json
+++ b/.devcontainer/slides/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Slides",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"image": "mcr.microsoft.com/devcontainers/base:bookworm",
 	"features": {
 	},
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.github/workflows/marp-pages.yml
+++ b/.github/workflows/marp-pages.yml
@@ -30,7 +30,7 @@ jobs:
         run: mkdir build && cp -R slides/img build/img && cp -R slides/themes build/themes
 
       - name: Marp Build (README)
-        uses: docker://marpteam/marp-cli:latest
+        uses: docker://marpteam/marp-cli:v4
         with:
           args: --theme-set slides/themes -o build/index.html --html -- slides/Slides.md
         env:


### PR DESCRIPTION
- Update devcontainer base images from Debian bullseye to bookworm
- Pin Marp CLI Docker image to v4 major version